### PR TITLE
node.loc および node.range の値を正しく設定する

### DIFF
--- a/lib/ReSTProcessor.js
+++ b/lib/ReSTProcessor.js
@@ -464,6 +464,58 @@ var require_structured_source = __commonJS({
   }
 });
 
+// node_modules/@textlint/ast-node-types/lib/src/index.js
+var require_src = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ASTNodeTypes = void 0;
+    var ASTNodeTypes3;
+    (function(ASTNodeTypes4) {
+      ASTNodeTypes4["Document"] = "Document";
+      ASTNodeTypes4["DocumentExit"] = "Document:exit";
+      ASTNodeTypes4["Paragraph"] = "Paragraph";
+      ASTNodeTypes4["ParagraphExit"] = "Paragraph:exit";
+      ASTNodeTypes4["BlockQuote"] = "BlockQuote";
+      ASTNodeTypes4["BlockQuoteExit"] = "BlockQuote:exit";
+      ASTNodeTypes4["ListItem"] = "ListItem";
+      ASTNodeTypes4["ListItemExit"] = "ListItem:exit";
+      ASTNodeTypes4["List"] = "List";
+      ASTNodeTypes4["ListExit"] = "List:exit";
+      ASTNodeTypes4["Header"] = "Header";
+      ASTNodeTypes4["HeaderExit"] = "Header:exit";
+      ASTNodeTypes4["CodeBlock"] = "CodeBlock";
+      ASTNodeTypes4["CodeBlockExit"] = "CodeBlock:exit";
+      ASTNodeTypes4["HtmlBlock"] = "HtmlBlock";
+      ASTNodeTypes4["HtmlBlockExit"] = "HtmlBlock:exit";
+      ASTNodeTypes4["HorizontalRule"] = "HorizontalRule";
+      ASTNodeTypes4["HorizontalRuleExit"] = "HorizontalRule:exit";
+      ASTNodeTypes4["Comment"] = "Comment";
+      ASTNodeTypes4["CommentExit"] = "Comment:exit";
+      ASTNodeTypes4["ReferenceDef"] = "ReferenceDef";
+      ASTNodeTypes4["ReferenceDefExit"] = "ReferenceDef:exit";
+      ASTNodeTypes4["Str"] = "Str";
+      ASTNodeTypes4["StrExit"] = "Str:exit";
+      ASTNodeTypes4["Break"] = "Break";
+      ASTNodeTypes4["BreakExit"] = "Break:exit";
+      ASTNodeTypes4["Emphasis"] = "Emphasis";
+      ASTNodeTypes4["EmphasisExit"] = "Emphasis:exit";
+      ASTNodeTypes4["Strong"] = "Strong";
+      ASTNodeTypes4["StrongExit"] = "Strong:exit";
+      ASTNodeTypes4["Html"] = "Html";
+      ASTNodeTypes4["HtmlExit"] = "Html:exit";
+      ASTNodeTypes4["Link"] = "Link";
+      ASTNodeTypes4["LinkExit"] = "Link:exit";
+      ASTNodeTypes4["Image"] = "Image";
+      ASTNodeTypes4["ImageExit"] = "Image:exit";
+      ASTNodeTypes4["Code"] = "Code";
+      ASTNodeTypes4["CodeExit"] = "Code:exit";
+      ASTNodeTypes4["Delete"] = "Delete";
+      ASTNodeTypes4["DeleteExit"] = "Delete:exit";
+    })(ASTNodeTypes3 = exports.ASTNodeTypes || (exports.ASTNodeTypes = {}));
+  }
+});
+
 // src/ReSTProcessor.ts
 var ReSTProcessor_exports = {};
 __export(ReSTProcessor_exports, {
@@ -477,22 +529,24 @@ var import_traverse = __toESM(require_traverse());
 var import_structured_source = __toESM(require_structured_source());
 
 // src/mapping.ts
+var import_ast_node_types = __toESM(require_src());
 var syntaxMap = {
-  "document": "Document",
-  "paragraph": "Paragraph",
-  "block_quote": "BlockQuote",
-  "list_item": "ListItem",
-  "bullet_list": "List",
-  "title": "Header",
-  "literal_block": "CodeBlock",
-  "reference": "Link",
-  "meta": "Html",
-  "text": "Str",
-  "emphasis": "Emphasis",
-  "strong": "Strong",
-  "image": "Image",
-  "inline": "Code",
-  "literal": "Code"
+  "document": import_ast_node_types.ASTNodeTypes.Document,
+  "paragraph": import_ast_node_types.ASTNodeTypes.Paragraph,
+  "block_quote": import_ast_node_types.ASTNodeTypes.BlockQuote,
+  "list_item": import_ast_node_types.ASTNodeTypes.ListItem,
+  "bullet_list": import_ast_node_types.ASTNodeTypes.List,
+  "title": import_ast_node_types.ASTNodeTypes.Header,
+  "literal_block": import_ast_node_types.ASTNodeTypes.CodeBlock,
+  "reference": import_ast_node_types.ASTNodeTypes.Link,
+  "meta": import_ast_node_types.ASTNodeTypes.Html,
+  "text": import_ast_node_types.ASTNodeTypes.Str,
+  "emphasis": import_ast_node_types.ASTNodeTypes.Emphasis,
+  "strong": import_ast_node_types.ASTNodeTypes.Strong,
+  "image": import_ast_node_types.ASTNodeTypes.Image,
+  "inline": import_ast_node_types.ASTNodeTypes.Code,
+  "literal": import_ast_node_types.ASTNodeTypes.Code,
+  "title-reference": import_ast_node_types.ASTNodeTypes.Header
 };
 var reSTAttributeKeyMap = {
   "tagname": "type",
@@ -501,6 +555,7 @@ var reSTAttributeKeyMap = {
 };
 
 // src/rst-to-ast.ts
+var import_ast_node_types2 = __toESM(require_src());
 function filterAndReplaceNodeAttributes(node) {
   Object.keys(reSTAttributeKeyMap).forEach((key) => {
     let v = node[key];
@@ -517,20 +572,39 @@ function parse(text) {
     if (this.notLeaf) {
       filterAndReplaceNodeAttributes(node);
       if (node.type === null) {
-        node.type = "text";
+        node.type = import_ast_node_types2.ASTNodeTypes.Str;
       }
       node.type = syntaxMap[node.type];
       if (!node.type) {
         node.type = "Unknown";
       }
       node.raw = node.raw || node.value || "";
-      let lines = node.raw.split("\n");
       if (node.line) {
-        node.loc = {
-          start: { line: node.line.start, column: 0 },
-          end: { line: node.line.end, column: lines[lines.length - 1].length }
-        };
-        node.range = src.locationToRange(node.loc);
+        if (node.raw.length === 0) {
+          node.loc = {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 0 }
+          };
+          node.range = [0, 0];
+        } else {
+          let searchStartPos = {
+            line: node.line.start,
+            column: 0
+          };
+          if (node.type === import_ast_node_types2.ASTNodeTypes.Header) {
+            searchStartPos.line -= 1;
+          }
+          const fromIndex = src.positionToIndex(searchStartPos);
+          let start = text.indexOf(node.raw, fromIndex);
+          let end = 0;
+          if (start < 0) {
+            start = 0;
+          } else {
+            end = start + node.raw.length;
+          }
+          node.range = [start, end];
+          node.loc = src.rangeToLocation(node.range);
+        }
         delete node.line;
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -464,6 +464,58 @@ var require_structured_source = __commonJS({
   }
 });
 
+// node_modules/@textlint/ast-node-types/lib/src/index.js
+var require_src = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ASTNodeTypes = void 0;
+    var ASTNodeTypes3;
+    (function(ASTNodeTypes4) {
+      ASTNodeTypes4["Document"] = "Document";
+      ASTNodeTypes4["DocumentExit"] = "Document:exit";
+      ASTNodeTypes4["Paragraph"] = "Paragraph";
+      ASTNodeTypes4["ParagraphExit"] = "Paragraph:exit";
+      ASTNodeTypes4["BlockQuote"] = "BlockQuote";
+      ASTNodeTypes4["BlockQuoteExit"] = "BlockQuote:exit";
+      ASTNodeTypes4["ListItem"] = "ListItem";
+      ASTNodeTypes4["ListItemExit"] = "ListItem:exit";
+      ASTNodeTypes4["List"] = "List";
+      ASTNodeTypes4["ListExit"] = "List:exit";
+      ASTNodeTypes4["Header"] = "Header";
+      ASTNodeTypes4["HeaderExit"] = "Header:exit";
+      ASTNodeTypes4["CodeBlock"] = "CodeBlock";
+      ASTNodeTypes4["CodeBlockExit"] = "CodeBlock:exit";
+      ASTNodeTypes4["HtmlBlock"] = "HtmlBlock";
+      ASTNodeTypes4["HtmlBlockExit"] = "HtmlBlock:exit";
+      ASTNodeTypes4["HorizontalRule"] = "HorizontalRule";
+      ASTNodeTypes4["HorizontalRuleExit"] = "HorizontalRule:exit";
+      ASTNodeTypes4["Comment"] = "Comment";
+      ASTNodeTypes4["CommentExit"] = "Comment:exit";
+      ASTNodeTypes4["ReferenceDef"] = "ReferenceDef";
+      ASTNodeTypes4["ReferenceDefExit"] = "ReferenceDef:exit";
+      ASTNodeTypes4["Str"] = "Str";
+      ASTNodeTypes4["StrExit"] = "Str:exit";
+      ASTNodeTypes4["Break"] = "Break";
+      ASTNodeTypes4["BreakExit"] = "Break:exit";
+      ASTNodeTypes4["Emphasis"] = "Emphasis";
+      ASTNodeTypes4["EmphasisExit"] = "Emphasis:exit";
+      ASTNodeTypes4["Strong"] = "Strong";
+      ASTNodeTypes4["StrongExit"] = "Strong:exit";
+      ASTNodeTypes4["Html"] = "Html";
+      ASTNodeTypes4["HtmlExit"] = "Html:exit";
+      ASTNodeTypes4["Link"] = "Link";
+      ASTNodeTypes4["LinkExit"] = "Link:exit";
+      ASTNodeTypes4["Image"] = "Image";
+      ASTNodeTypes4["ImageExit"] = "Image:exit";
+      ASTNodeTypes4["Code"] = "Code";
+      ASTNodeTypes4["CodeExit"] = "Code:exit";
+      ASTNodeTypes4["Delete"] = "Delete";
+      ASTNodeTypes4["DeleteExit"] = "Delete:exit";
+    })(ASTNodeTypes3 = exports.ASTNodeTypes || (exports.ASTNodeTypes = {}));
+  }
+});
+
 // src/index.ts
 var src_exports = {};
 __export(src_exports, {
@@ -477,22 +529,24 @@ var import_traverse = __toESM(require_traverse());
 var import_structured_source = __toESM(require_structured_source());
 
 // src/mapping.ts
+var import_ast_node_types = __toESM(require_src());
 var syntaxMap = {
-  "document": "Document",
-  "paragraph": "Paragraph",
-  "block_quote": "BlockQuote",
-  "list_item": "ListItem",
-  "bullet_list": "List",
-  "title": "Header",
-  "literal_block": "CodeBlock",
-  "reference": "Link",
-  "meta": "Html",
-  "text": "Str",
-  "emphasis": "Emphasis",
-  "strong": "Strong",
-  "image": "Image",
-  "inline": "Code",
-  "literal": "Code"
+  "document": import_ast_node_types.ASTNodeTypes.Document,
+  "paragraph": import_ast_node_types.ASTNodeTypes.Paragraph,
+  "block_quote": import_ast_node_types.ASTNodeTypes.BlockQuote,
+  "list_item": import_ast_node_types.ASTNodeTypes.ListItem,
+  "bullet_list": import_ast_node_types.ASTNodeTypes.List,
+  "title": import_ast_node_types.ASTNodeTypes.Header,
+  "literal_block": import_ast_node_types.ASTNodeTypes.CodeBlock,
+  "reference": import_ast_node_types.ASTNodeTypes.Link,
+  "meta": import_ast_node_types.ASTNodeTypes.Html,
+  "text": import_ast_node_types.ASTNodeTypes.Str,
+  "emphasis": import_ast_node_types.ASTNodeTypes.Emphasis,
+  "strong": import_ast_node_types.ASTNodeTypes.Strong,
+  "image": import_ast_node_types.ASTNodeTypes.Image,
+  "inline": import_ast_node_types.ASTNodeTypes.Code,
+  "literal": import_ast_node_types.ASTNodeTypes.Code,
+  "title-reference": import_ast_node_types.ASTNodeTypes.Header
 };
 var reSTAttributeKeyMap = {
   "tagname": "type",
@@ -501,6 +555,7 @@ var reSTAttributeKeyMap = {
 };
 
 // src/rst-to-ast.ts
+var import_ast_node_types2 = __toESM(require_src());
 function filterAndReplaceNodeAttributes(node) {
   Object.keys(reSTAttributeKeyMap).forEach((key) => {
     let v = node[key];
@@ -517,20 +572,39 @@ function parse(text) {
     if (this.notLeaf) {
       filterAndReplaceNodeAttributes(node);
       if (node.type === null) {
-        node.type = "text";
+        node.type = import_ast_node_types2.ASTNodeTypes.Str;
       }
       node.type = syntaxMap[node.type];
       if (!node.type) {
         node.type = "Unknown";
       }
       node.raw = node.raw || node.value || "";
-      let lines = node.raw.split("\n");
       if (node.line) {
-        node.loc = {
-          start: { line: node.line.start, column: 0 },
-          end: { line: node.line.end, column: lines[lines.length - 1].length }
-        };
-        node.range = src.locationToRange(node.loc);
+        if (node.raw.length === 0) {
+          node.loc = {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 0 }
+          };
+          node.range = [0, 0];
+        } else {
+          let searchStartPos = {
+            line: node.line.start,
+            column: 0
+          };
+          if (node.type === import_ast_node_types2.ASTNodeTypes.Header) {
+            searchStartPos.line -= 1;
+          }
+          const fromIndex = src.positionToIndex(searchStartPos);
+          let start = text.indexOf(node.raw, fromIndex);
+          let end = 0;
+          if (start < 0) {
+            start = 0;
+          } else {
+            end = start + node.raw.length;
+          }
+          node.range = [start, end];
+          node.loc = src.rangeToLocation(node.range);
+        }
         delete node.line;
       }
     }

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -1,8 +1,13 @@
 "use strict";
+var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
 var __export = (target, all) => {
   for (var name in all)
     __defProp(target, name, { get: all[name], enumerable: true });
@@ -15,7 +20,67 @@ var __copyProps = (to, from, except, desc) => {
   }
   return to;
 };
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/@textlint/ast-node-types/lib/src/index.js
+var require_src = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ASTNodeTypes = void 0;
+    var ASTNodeTypes2;
+    (function(ASTNodeTypes3) {
+      ASTNodeTypes3["Document"] = "Document";
+      ASTNodeTypes3["DocumentExit"] = "Document:exit";
+      ASTNodeTypes3["Paragraph"] = "Paragraph";
+      ASTNodeTypes3["ParagraphExit"] = "Paragraph:exit";
+      ASTNodeTypes3["BlockQuote"] = "BlockQuote";
+      ASTNodeTypes3["BlockQuoteExit"] = "BlockQuote:exit";
+      ASTNodeTypes3["ListItem"] = "ListItem";
+      ASTNodeTypes3["ListItemExit"] = "ListItem:exit";
+      ASTNodeTypes3["List"] = "List";
+      ASTNodeTypes3["ListExit"] = "List:exit";
+      ASTNodeTypes3["Header"] = "Header";
+      ASTNodeTypes3["HeaderExit"] = "Header:exit";
+      ASTNodeTypes3["CodeBlock"] = "CodeBlock";
+      ASTNodeTypes3["CodeBlockExit"] = "CodeBlock:exit";
+      ASTNodeTypes3["HtmlBlock"] = "HtmlBlock";
+      ASTNodeTypes3["HtmlBlockExit"] = "HtmlBlock:exit";
+      ASTNodeTypes3["HorizontalRule"] = "HorizontalRule";
+      ASTNodeTypes3["HorizontalRuleExit"] = "HorizontalRule:exit";
+      ASTNodeTypes3["Comment"] = "Comment";
+      ASTNodeTypes3["CommentExit"] = "Comment:exit";
+      ASTNodeTypes3["ReferenceDef"] = "ReferenceDef";
+      ASTNodeTypes3["ReferenceDefExit"] = "ReferenceDef:exit";
+      ASTNodeTypes3["Str"] = "Str";
+      ASTNodeTypes3["StrExit"] = "Str:exit";
+      ASTNodeTypes3["Break"] = "Break";
+      ASTNodeTypes3["BreakExit"] = "Break:exit";
+      ASTNodeTypes3["Emphasis"] = "Emphasis";
+      ASTNodeTypes3["EmphasisExit"] = "Emphasis:exit";
+      ASTNodeTypes3["Strong"] = "Strong";
+      ASTNodeTypes3["StrongExit"] = "Strong:exit";
+      ASTNodeTypes3["Html"] = "Html";
+      ASTNodeTypes3["HtmlExit"] = "Html:exit";
+      ASTNodeTypes3["Link"] = "Link";
+      ASTNodeTypes3["LinkExit"] = "Link:exit";
+      ASTNodeTypes3["Image"] = "Image";
+      ASTNodeTypes3["ImageExit"] = "Image:exit";
+      ASTNodeTypes3["Code"] = "Code";
+      ASTNodeTypes3["CodeExit"] = "Code:exit";
+      ASTNodeTypes3["Delete"] = "Delete";
+      ASTNodeTypes3["DeleteExit"] = "Delete:exit";
+    })(ASTNodeTypes2 = exports.ASTNodeTypes || (exports.ASTNodeTypes = {}));
+  }
+});
 
 // src/mapping.ts
 var mapping_exports = {};
@@ -24,22 +89,24 @@ __export(mapping_exports, {
   syntaxMap: () => syntaxMap
 });
 module.exports = __toCommonJS(mapping_exports);
+var import_ast_node_types = __toESM(require_src());
 var syntaxMap = {
-  "document": "Document",
-  "paragraph": "Paragraph",
-  "block_quote": "BlockQuote",
-  "list_item": "ListItem",
-  "bullet_list": "List",
-  "title": "Header",
-  "literal_block": "CodeBlock",
-  "reference": "Link",
-  "meta": "Html",
-  "text": "Str",
-  "emphasis": "Emphasis",
-  "strong": "Strong",
-  "image": "Image",
-  "inline": "Code",
-  "literal": "Code"
+  "document": import_ast_node_types.ASTNodeTypes.Document,
+  "paragraph": import_ast_node_types.ASTNodeTypes.Paragraph,
+  "block_quote": import_ast_node_types.ASTNodeTypes.BlockQuote,
+  "list_item": import_ast_node_types.ASTNodeTypes.ListItem,
+  "bullet_list": import_ast_node_types.ASTNodeTypes.List,
+  "title": import_ast_node_types.ASTNodeTypes.Header,
+  "literal_block": import_ast_node_types.ASTNodeTypes.CodeBlock,
+  "reference": import_ast_node_types.ASTNodeTypes.Link,
+  "meta": import_ast_node_types.ASTNodeTypes.Html,
+  "text": import_ast_node_types.ASTNodeTypes.Str,
+  "emphasis": import_ast_node_types.ASTNodeTypes.Emphasis,
+  "strong": import_ast_node_types.ASTNodeTypes.Strong,
+  "image": import_ast_node_types.ASTNodeTypes.Image,
+  "inline": import_ast_node_types.ASTNodeTypes.Code,
+  "literal": import_ast_node_types.ASTNodeTypes.Code,
+  "title-reference": import_ast_node_types.ASTNodeTypes.Header
 };
 var reSTAttributeKeyMap = {
   "tagname": "type",

--- a/lib/rst-to-ast.js
+++ b/lib/rst-to-ast.js
@@ -464,6 +464,58 @@ var require_structured_source = __commonJS({
   }
 });
 
+// node_modules/@textlint/ast-node-types/lib/src/index.js
+var require_src = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ASTNodeTypes = void 0;
+    var ASTNodeTypes3;
+    (function(ASTNodeTypes4) {
+      ASTNodeTypes4["Document"] = "Document";
+      ASTNodeTypes4["DocumentExit"] = "Document:exit";
+      ASTNodeTypes4["Paragraph"] = "Paragraph";
+      ASTNodeTypes4["ParagraphExit"] = "Paragraph:exit";
+      ASTNodeTypes4["BlockQuote"] = "BlockQuote";
+      ASTNodeTypes4["BlockQuoteExit"] = "BlockQuote:exit";
+      ASTNodeTypes4["ListItem"] = "ListItem";
+      ASTNodeTypes4["ListItemExit"] = "ListItem:exit";
+      ASTNodeTypes4["List"] = "List";
+      ASTNodeTypes4["ListExit"] = "List:exit";
+      ASTNodeTypes4["Header"] = "Header";
+      ASTNodeTypes4["HeaderExit"] = "Header:exit";
+      ASTNodeTypes4["CodeBlock"] = "CodeBlock";
+      ASTNodeTypes4["CodeBlockExit"] = "CodeBlock:exit";
+      ASTNodeTypes4["HtmlBlock"] = "HtmlBlock";
+      ASTNodeTypes4["HtmlBlockExit"] = "HtmlBlock:exit";
+      ASTNodeTypes4["HorizontalRule"] = "HorizontalRule";
+      ASTNodeTypes4["HorizontalRuleExit"] = "HorizontalRule:exit";
+      ASTNodeTypes4["Comment"] = "Comment";
+      ASTNodeTypes4["CommentExit"] = "Comment:exit";
+      ASTNodeTypes4["ReferenceDef"] = "ReferenceDef";
+      ASTNodeTypes4["ReferenceDefExit"] = "ReferenceDef:exit";
+      ASTNodeTypes4["Str"] = "Str";
+      ASTNodeTypes4["StrExit"] = "Str:exit";
+      ASTNodeTypes4["Break"] = "Break";
+      ASTNodeTypes4["BreakExit"] = "Break:exit";
+      ASTNodeTypes4["Emphasis"] = "Emphasis";
+      ASTNodeTypes4["EmphasisExit"] = "Emphasis:exit";
+      ASTNodeTypes4["Strong"] = "Strong";
+      ASTNodeTypes4["StrongExit"] = "Strong:exit";
+      ASTNodeTypes4["Html"] = "Html";
+      ASTNodeTypes4["HtmlExit"] = "Html:exit";
+      ASTNodeTypes4["Link"] = "Link";
+      ASTNodeTypes4["LinkExit"] = "Link:exit";
+      ASTNodeTypes4["Image"] = "Image";
+      ASTNodeTypes4["ImageExit"] = "Image:exit";
+      ASTNodeTypes4["Code"] = "Code";
+      ASTNodeTypes4["CodeExit"] = "Code:exit";
+      ASTNodeTypes4["Delete"] = "Delete";
+      ASTNodeTypes4["DeleteExit"] = "Delete:exit";
+    })(ASTNodeTypes3 = exports.ASTNodeTypes || (exports.ASTNodeTypes = {}));
+  }
+});
+
 // src/rst-to-ast.ts
 var rst_to_ast_exports = {};
 __export(rst_to_ast_exports, {
@@ -475,22 +527,24 @@ var import_traverse = __toESM(require_traverse());
 var import_structured_source = __toESM(require_structured_source());
 
 // src/mapping.ts
+var import_ast_node_types = __toESM(require_src());
 var syntaxMap = {
-  "document": "Document",
-  "paragraph": "Paragraph",
-  "block_quote": "BlockQuote",
-  "list_item": "ListItem",
-  "bullet_list": "List",
-  "title": "Header",
-  "literal_block": "CodeBlock",
-  "reference": "Link",
-  "meta": "Html",
-  "text": "Str",
-  "emphasis": "Emphasis",
-  "strong": "Strong",
-  "image": "Image",
-  "inline": "Code",
-  "literal": "Code"
+  "document": import_ast_node_types.ASTNodeTypes.Document,
+  "paragraph": import_ast_node_types.ASTNodeTypes.Paragraph,
+  "block_quote": import_ast_node_types.ASTNodeTypes.BlockQuote,
+  "list_item": import_ast_node_types.ASTNodeTypes.ListItem,
+  "bullet_list": import_ast_node_types.ASTNodeTypes.List,
+  "title": import_ast_node_types.ASTNodeTypes.Header,
+  "literal_block": import_ast_node_types.ASTNodeTypes.CodeBlock,
+  "reference": import_ast_node_types.ASTNodeTypes.Link,
+  "meta": import_ast_node_types.ASTNodeTypes.Html,
+  "text": import_ast_node_types.ASTNodeTypes.Str,
+  "emphasis": import_ast_node_types.ASTNodeTypes.Emphasis,
+  "strong": import_ast_node_types.ASTNodeTypes.Strong,
+  "image": import_ast_node_types.ASTNodeTypes.Image,
+  "inline": import_ast_node_types.ASTNodeTypes.Code,
+  "literal": import_ast_node_types.ASTNodeTypes.Code,
+  "title-reference": import_ast_node_types.ASTNodeTypes.Header
 };
 var reSTAttributeKeyMap = {
   "tagname": "type",
@@ -499,6 +553,7 @@ var reSTAttributeKeyMap = {
 };
 
 // src/rst-to-ast.ts
+var import_ast_node_types2 = __toESM(require_src());
 function filterAndReplaceNodeAttributes(node) {
   Object.keys(reSTAttributeKeyMap).forEach((key) => {
     let v = node[key];
@@ -515,20 +570,39 @@ function parse(text) {
     if (this.notLeaf) {
       filterAndReplaceNodeAttributes(node);
       if (node.type === null) {
-        node.type = "text";
+        node.type = import_ast_node_types2.ASTNodeTypes.Str;
       }
       node.type = syntaxMap[node.type];
       if (!node.type) {
         node.type = "Unknown";
       }
       node.raw = node.raw || node.value || "";
-      let lines = node.raw.split("\n");
       if (node.line) {
-        node.loc = {
-          start: { line: node.line.start, column: 0 },
-          end: { line: node.line.end, column: lines[lines.length - 1].length }
-        };
-        node.range = src.locationToRange(node.loc);
+        if (node.raw.length === 0) {
+          node.loc = {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 0 }
+          };
+          node.range = [0, 0];
+        } else {
+          let searchStartPos = {
+            line: node.line.start,
+            column: 0
+          };
+          if (node.type === import_ast_node_types2.ASTNodeTypes.Header) {
+            searchStartPos.line -= 1;
+          }
+          const fromIndex = src.positionToIndex(searchStartPos);
+          let start = text.indexOf(node.raw, fromIndex);
+          let end = 0;
+          if (start < 0) {
+            start = 0;
+          } else {
+            end = start + node.raw.length;
+          }
+          node.range = [start, end];
+          node.loc = src.rangeToLocation(node.range);
+        }
         delete node.line;
       }
     }

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -1,25 +1,35 @@
 // LICENSE : MIT
 "use strict";
+import { ASTNodeTypes } from "@textlint/ast-node-types";
 
-export const syntaxMap = {
-    "document": "Document",
-    "paragraph": "Paragraph",
-    "block_quote": "BlockQuote",
-    "list_item": "ListItem",
-    "bullet_list": "List",
-    "title": "Header",
-    "literal_block": "CodeBlock",
-    "reference": "Link",
-    "meta": "Html",
-    "text": "Str",
-    "emphasis": "Emphasis",
-    "strong": "Strong",
-    "image": "Image",
-    "inline": "Code",
-    "literal": "Code"
+interface SyntaxMap {
+    [index: string]: ASTNodeTypes
+}
+
+export const syntaxMap: SyntaxMap = {
+    "document": ASTNodeTypes.Document,
+    "paragraph": ASTNodeTypes.Paragraph,
+    "block_quote": ASTNodeTypes.BlockQuote,
+    "list_item": ASTNodeTypes.ListItem,
+    "bullet_list": ASTNodeTypes.List,
+    "title": ASTNodeTypes.Header,
+    "literal_block": ASTNodeTypes.CodeBlock,
+    "reference": ASTNodeTypes.Link,
+    "meta": ASTNodeTypes.Html,
+    "text": ASTNodeTypes.Str,
+    "emphasis": ASTNodeTypes.Emphasis,
+    "strong": ASTNodeTypes.Strong,
+    "image": ASTNodeTypes.Image,
+    "inline": ASTNodeTypes.Code,
+    "literal": ASTNodeTypes.Code,
+    "title-reference": ASTNodeTypes.Header
 };
 
-export const reSTAttributeKeyMap = {
+interface ReSTAttributeKeyMap {
+    [index: string]: string
+}
+
+export const reSTAttributeKeyMap: ReSTAttributeKeyMap = {
     "tagname": "type",
     "rawsource": "raw",
     "text": "value"

--- a/src/rst-to-ast.ts
+++ b/src/rst-to-ast.ts
@@ -4,7 +4,7 @@ import { execSync } from 'child_process'
 import traverse from 'traverse'
 import { StructuredSource } from 'structured-source'
 import { syntaxMap, reSTAttributeKeyMap } from './mapping'
-import type { TxtNode } from "@textlint/ast-node-types";
+import { TxtNode, ASTNodeTypes } from "@textlint/ast-node-types";
 
 function filterAndReplaceNodeAttributes(node: TxtNode) {
   Object.keys(reSTAttributeKeyMap).forEach((key) => {
@@ -24,12 +24,15 @@ function filterAndReplaceNodeAttributes(node: TxtNode) {
 export function parse(text: string): any {
   let ast = JSON.parse(execSync('rst2ast -q', { input: text, maxBuffer: 8192 * 8192 }))
   const src = new StructuredSource(text)
+
   traverse(ast).forEach(function (node: TxtNode) {
     if (this.notLeaf) {
       filterAndReplaceNodeAttributes(node)
+      // console.log("===== node ===============================")
+      // console.dir(node, {depth: null})
       // type
       if (node.type === null) {
-        node.type = 'text'
+        node.type = ASTNodeTypes.Str
       }
       node.type = syntaxMap[node.type]
       if (!node.type) {
@@ -38,13 +41,51 @@ export function parse(text: string): any {
       // raw
       node.raw = node.raw || node.value || ''
       // loc
-      let lines = node.raw.split('\n')
       if (node.line) {
-        node.loc = {
-          start: { line: node.line.start, column: 0 },
-          end: { line: node.line.end, column: lines[lines.length - 1].length },
+        if (node.raw.length === 0) {
+          node.loc = {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 0 },
+          }
+          node.range = [0, 0]
+        } else {
+          let searchStartPos = {
+            line: node.line.start,
+            column: 0,
+          }
+          // Header の場合 node.line.start が1行下にずれるので補正する。
+          // (rst2ast のバグの可能性もある)
+          if (node.type === ASTNodeTypes.Header) {
+            searchStartPos.line -= 1
+          }
+          const fromIndex = src.positionToIndex(searchStartPos)
+          // DEBUG
+          // console.log("--------------------------")
+          // console.log(`fromIndex: ${fromIndex}`)
+          // console.log(`substr (20): ${text.substring(fromIndex, fromIndex+20)}`)
+          let start = text.indexOf(node.raw, fromIndex)
+          let end = 0
+          // 見つからない場合は range = [0, 0] を設定
+          if (start < 0) {
+            start = 0
+          } else {
+            end = start + node.raw.length
+          }
+          node.range = [start, end]
+          node.loc = src.rangeToLocation(node.range)
         }
-        node.range = src.locationToRange(node.loc)
+        // DEBUG
+        // if (node.range[0] === 0 && node.range[1] === 0) {
+        //   console.log("-------------------------")
+        //   console.log(`node.line:`)
+        //   console.dir(node.line, { depth: null })
+        //   console.log(`node.type: ${node.type}`)
+        //   console.log(`node.raw: ${node.raw}`)
+        //   console.log(`node.range: ${node.range[0]} - ${node.range[1]}`)
+        //   console.log(`node.loc:`)
+        //   console.dir(node.loc, { depth: null })
+        //   console.log(`cut: ${text.substring(node.range[0], node.range[1])}`)
+        // }
         delete node.line
       }
     }


### PR DESCRIPTION
node.loc および node.range の値が誤っていると、textlint 側で文字列の切り出しを行ったときに本来とは異なる結果になる。よって修正が必要。
node.loc および node.range の値を決めるにあたり rst2ast の結果からは行情報しか得られないため、列の位置はこのプラグイン内で特定してやる必要がある。これを実装した。

既知の問題: codeblock を正しく解釈できない