### PR TITLE
code-block や warning などのブロックが正しく認識されるように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ $ npx textlint --plugin rst source/
 }
 ```
 
-## 既知の問題
-
-**協力者募集中**
-
-- codeblock を正しく解釈できない
-
 ## ライセンス
 
 ```

--- a/lib/ReSTProcessor.js
+++ b/lib/ReSTProcessor.js
@@ -579,9 +579,22 @@ function parse(text, options) {
   const isDebug = process.env.DEBUG?.startsWith("textlint:rst") ?? options?.debug ?? false;
   const ast = JSON.parse((0, import_child_process.execSync)("rst2ast -q", { input: text, maxBuffer: 8192 * 8192 }).toString());
   const src = new import_structured_source.StructuredSource(text);
-  const typesNeedCalibration = [
-    import_ast_node_types2.ASTNodeTypes.Header,
-    import_ast_node_types2.ASTNodeTypes.Comment
+  const originalTypesNeedCalibration = [
+    "title",
+    "comment",
+    "literal_block",
+    // Sphinx builtin directives
+    // https://sphinx-users.jp/gettingstarted/directives.html
+    "attention",
+    "caution",
+    "danger",
+    "error",
+    "hint",
+    "important",
+    "note",
+    "tip",
+    "warning",
+    "admonition"
   ];
   (0, import_traverse.default)(ast).forEach(function(node) {
     if (this.notLeaf) {
@@ -593,16 +606,16 @@ function parse(text, options) {
       if (isDebug) {
         console.log("===== node (raw) ===================");
         console.dir(node, { depth: null });
-        console.log("===== parent node ==================");
-        console.log(parentNode);
       }
       if (parentNode && parentNode.type === import_ast_node_types2.ASTNodeTypes.Comment) {
         return;
       }
-      if (node.type === null) {
+      node.original_type = node.type;
+      if (node.original_type === null) {
         node.type = import_ast_node_types2.ASTNodeTypes.Str;
+      } else {
+        node.type = syntaxMap[node.original_type];
       }
-      node.type = syntaxMap[node.type];
       if (!node.type) {
         node.type = "Unknown";
       }
@@ -629,11 +642,11 @@ function parse(text, options) {
           };
           if (node.type === import_ast_node_types2.ASTNodeTypes.Header) {
             searchStartPos.line -= 1;
-          } else if (node.type === import_ast_node_types2.ASTNodeTypes.Comment) {
+          } else if (originalTypesNeedCalibration.includes(node.original_type)) {
             const fromIndex2 = src.positionToIndex(searchStartPos);
             const start2 = text.lastIndexOf("\n..", fromIndex2);
             searchStartPos = src.indexToPosition(start2);
-          } else if (parentNode && parentNode.type && typesNeedCalibration.includes(parentNode.type)) {
+          } else if (parentNode && parentNode.type && originalTypesNeedCalibration.includes(parentNode.original_type)) {
             searchStartPos.line -= 1;
           }
           const fromIndex = src.positionToIndex(searchStartPos);
@@ -693,7 +706,7 @@ function indexOfMultiLineWithoutLspaces(text, search_str, position) {
   for (let i = 0; i < search_strings.length; i++) {
     const result = scanner.next();
     const line = result.value;
-    if (line.trimStart() !== search_strings[i]) {
+    if (line.trimStart() !== search_strings[i].trimStart()) {
       return -1;
     }
     if (result.done && search_strings.length - i > 1) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -579,9 +579,22 @@ function parse(text, options) {
   const isDebug = process.env.DEBUG?.startsWith("textlint:rst") ?? options?.debug ?? false;
   const ast = JSON.parse((0, import_child_process.execSync)("rst2ast -q", { input: text, maxBuffer: 8192 * 8192 }).toString());
   const src = new import_structured_source.StructuredSource(text);
-  const typesNeedCalibration = [
-    import_ast_node_types2.ASTNodeTypes.Header,
-    import_ast_node_types2.ASTNodeTypes.Comment
+  const originalTypesNeedCalibration = [
+    "title",
+    "comment",
+    "literal_block",
+    // Sphinx builtin directives
+    // https://sphinx-users.jp/gettingstarted/directives.html
+    "attention",
+    "caution",
+    "danger",
+    "error",
+    "hint",
+    "important",
+    "note",
+    "tip",
+    "warning",
+    "admonition"
   ];
   (0, import_traverse.default)(ast).forEach(function(node) {
     if (this.notLeaf) {
@@ -593,16 +606,16 @@ function parse(text, options) {
       if (isDebug) {
         console.log("===== node (raw) ===================");
         console.dir(node, { depth: null });
-        console.log("===== parent node ==================");
-        console.log(parentNode);
       }
       if (parentNode && parentNode.type === import_ast_node_types2.ASTNodeTypes.Comment) {
         return;
       }
-      if (node.type === null) {
+      node.original_type = node.type;
+      if (node.original_type === null) {
         node.type = import_ast_node_types2.ASTNodeTypes.Str;
+      } else {
+        node.type = syntaxMap[node.original_type];
       }
-      node.type = syntaxMap[node.type];
       if (!node.type) {
         node.type = "Unknown";
       }
@@ -629,11 +642,11 @@ function parse(text, options) {
           };
           if (node.type === import_ast_node_types2.ASTNodeTypes.Header) {
             searchStartPos.line -= 1;
-          } else if (node.type === import_ast_node_types2.ASTNodeTypes.Comment) {
+          } else if (originalTypesNeedCalibration.includes(node.original_type)) {
             const fromIndex2 = src.positionToIndex(searchStartPos);
             const start2 = text.lastIndexOf("\n..", fromIndex2);
             searchStartPos = src.indexToPosition(start2);
-          } else if (parentNode && parentNode.type && typesNeedCalibration.includes(parentNode.type)) {
+          } else if (parentNode && parentNode.type && originalTypesNeedCalibration.includes(parentNode.original_type)) {
             searchStartPos.line -= 1;
           }
           const fromIndex = src.positionToIndex(searchStartPos);
@@ -693,7 +706,7 @@ function indexOfMultiLineWithoutLspaces(text, search_str, position) {
   for (let i = 0; i < search_strings.length; i++) {
     const result = scanner.next();
     const line = result.value;
-    if (line.trimStart() !== search_strings[i]) {
+    if (line.trimStart() !== search_strings[i].trimStart()) {
       return -1;
     }
     if (result.done && search_strings.length - i > 1) {

--- a/lib/rst-to-ast.js
+++ b/lib/rst-to-ast.js
@@ -578,9 +578,22 @@ function parse(text, options) {
   const isDebug = process.env.DEBUG?.startsWith("textlint:rst") ?? options?.debug ?? false;
   const ast = JSON.parse((0, import_child_process.execSync)("rst2ast -q", { input: text, maxBuffer: 8192 * 8192 }).toString());
   const src = new import_structured_source.StructuredSource(text);
-  const typesNeedCalibration = [
-    import_ast_node_types2.ASTNodeTypes.Header,
-    import_ast_node_types2.ASTNodeTypes.Comment
+  const originalTypesNeedCalibration = [
+    "title",
+    "comment",
+    "literal_block",
+    // Sphinx builtin directives
+    // https://sphinx-users.jp/gettingstarted/directives.html
+    "attention",
+    "caution",
+    "danger",
+    "error",
+    "hint",
+    "important",
+    "note",
+    "tip",
+    "warning",
+    "admonition"
   ];
   (0, import_traverse.default)(ast).forEach(function(node) {
     if (this.notLeaf) {
@@ -592,16 +605,16 @@ function parse(text, options) {
       if (isDebug) {
         console.log("===== node (raw) ===================");
         console.dir(node, { depth: null });
-        console.log("===== parent node ==================");
-        console.log(parentNode);
       }
       if (parentNode && parentNode.type === import_ast_node_types2.ASTNodeTypes.Comment) {
         return;
       }
-      if (node.type === null) {
+      node.original_type = node.type;
+      if (node.original_type === null) {
         node.type = import_ast_node_types2.ASTNodeTypes.Str;
+      } else {
+        node.type = syntaxMap[node.original_type];
       }
-      node.type = syntaxMap[node.type];
       if (!node.type) {
         node.type = "Unknown";
       }
@@ -628,11 +641,11 @@ function parse(text, options) {
           };
           if (node.type === import_ast_node_types2.ASTNodeTypes.Header) {
             searchStartPos.line -= 1;
-          } else if (node.type === import_ast_node_types2.ASTNodeTypes.Comment) {
+          } else if (originalTypesNeedCalibration.includes(node.original_type)) {
             const fromIndex2 = src.positionToIndex(searchStartPos);
             const start2 = text.lastIndexOf("\n..", fromIndex2);
             searchStartPos = src.indexToPosition(start2);
-          } else if (parentNode && parentNode.type && typesNeedCalibration.includes(parentNode.type)) {
+          } else if (parentNode && parentNode.type && originalTypesNeedCalibration.includes(parentNode.original_type)) {
             searchStartPos.line -= 1;
           }
           const fromIndex = src.positionToIndex(searchStartPos);
@@ -692,7 +705,7 @@ function indexOfMultiLineWithoutLspaces(text, search_str, position) {
   for (let i = 0; i < search_strings.length; i++) {
     const result = scanner.next();
     const line = result.value;
-    if (line.trimStart() !== search_strings[i]) {
+    if (line.trimStart() !== search_strings[i].trimStart()) {
       return -1;
     }
     if (result.done && search_strings.length - i > 1) {

--- a/test/rst-to-ast-test.ts
+++ b/test/rst-to-ast-test.ts
@@ -53,12 +53,24 @@ describe("indexOfMultiLineWithoutLspaces", () => {
     複数行
     コメント
 
+.. code-block:: javascript
+
+    {
+        "type": "dog"
+    }
+
 終わり`
 
-    it("found", () => {
+    it("found in comment", () => {
         const search_str = "複数行\nコメント"
         const actual = indexOfMultiLineWithoutLspaces(text, search_str, 9)
         assert.equal(actual, 16)
+    })
+
+    it("found in code-block", () => {
+        const search_str = '{\n    "type": "dog"\n}'
+        const actual = indexOfMultiLineWithoutLspaces(text, search_str, 30)
+        assert.equal(actual, 62)
     })
 
     it("not found", () => {

--- a/test/testcases/basic/expected.json
+++ b/test/testcases/basic/expected.json
@@ -9,6 +9,7 @@
           "type": "Str",
           "raw": "タイトル",
           "value": "タイトル",
+          "original_type": "text",
           "range": [
             0,
             4
@@ -27,6 +28,7 @@
       ],
       "type": "Header",
       "raw": "タイトル",
+      "original_type": "title",
       "range": [
         0,
         4
@@ -49,6 +51,7 @@
           "type": "Str",
           "raw": "テキスト",
           "value": "テキスト",
+          "original_type": "text",
           "range": [
             15,
             19
@@ -67,6 +70,7 @@
       ],
       "type": "Paragraph",
       "raw": "テキスト",
+      "original_type": "paragraph",
       "range": [
         15,
         19
@@ -95,6 +99,7 @@
                   "type": "Str",
                   "raw": "リスト1",
                   "value": "リスト1",
+                  "original_type": "text",
                   "range": [
                     23,
                     27
@@ -113,6 +118,7 @@
               ],
               "type": "Paragraph",
               "raw": "リスト1",
+              "original_type": "paragraph",
               "range": [
                 23,
                 27
@@ -143,6 +149,7 @@
                               "type": "Str",
                               "raw": "ネスト1",
                               "value": "ネスト1",
+                              "original_type": "text",
                               "range": [
                                 34,
                                 38
@@ -161,6 +168,7 @@
                           ],
                           "type": "Paragraph",
                           "raw": "ネスト1",
+                          "original_type": "paragraph",
                           "range": [
                             34,
                             38
@@ -179,6 +187,7 @@
                       ],
                       "type": "ListItem",
                       "raw": "ネスト1",
+                      "original_type": "list_item",
                       "range": [
                         34,
                         38
@@ -203,6 +212,7 @@
                               "type": "Str",
                               "raw": "ネスト2",
                               "value": "ネスト2",
+                              "original_type": "text",
                               "range": [
                                 44,
                                 48
@@ -221,6 +231,7 @@
                           ],
                           "type": "Paragraph",
                           "raw": "ネスト2",
+                          "original_type": "paragraph",
                           "range": [
                             44,
                             48
@@ -239,6 +250,7 @@
                       ],
                       "type": "ListItem",
                       "raw": "ネスト2\n",
+                      "original_type": "list_item",
                       "range": [
                         44,
                         49
@@ -257,6 +269,7 @@
                   ],
                   "type": "List",
                   "raw": "",
+                  "original_type": "bullet_list",
                   "loc": {
                     "start": {
                       "line": 8,
@@ -275,6 +288,7 @@
               ],
               "type": "BlockQuote",
               "raw": "- ネスト1\n- ネスト2\n",
+              "original_type": "block_quote",
               "range": [
                 32,
                 46
@@ -293,18 +307,19 @@
           ],
           "type": "ListItem",
           "raw": "リスト1\n\n - ネスト1\n - ネスト2\n",
+          "original_type": "list_item",
           "range": [
-            0,
-            0
+            23,
+            45
           ],
           "loc": {
             "start": {
-              "line": 1,
-              "column": 0
+              "line": 6,
+              "column": 2
             },
             "end": {
-              "line": 1,
-              "column": 0
+              "line": 9,
+              "column": 6
             }
           }
         },
@@ -318,6 +333,7 @@
                   "type": "Str",
                   "raw": "リスト2",
                   "value": "リスト2",
+                  "original_type": "text",
                   "range": [
                     52,
                     56
@@ -336,6 +352,7 @@
               ],
               "type": "Paragraph",
               "raw": "リスト2",
+              "original_type": "paragraph",
               "range": [
                 52,
                 56
@@ -354,6 +371,7 @@
           ],
           "type": "ListItem",
           "raw": "リスト2",
+          "original_type": "list_item",
           "range": [
             52,
             56
@@ -379,6 +397,7 @@
                   "type": "Str",
                   "raw": "リスト3",
                   "value": "リスト3",
+                  "original_type": "text",
                   "range": [
                     59,
                     63
@@ -397,6 +416,7 @@
               ],
               "type": "Paragraph",
               "raw": "リスト3",
+              "original_type": "paragraph",
               "range": [
                 59,
                 63
@@ -415,6 +435,7 @@
           ],
           "type": "ListItem",
           "raw": "リスト3",
+          "original_type": "list_item",
           "range": [
             59,
             63
@@ -433,6 +454,7 @@
       ],
       "type": "List",
       "raw": "",
+      "original_type": "bullet_list",
       "loc": {
         "start": {
           "line": 6,
@@ -451,6 +473,7 @@
   ],
   "type": "Document",
   "raw": "",
+  "original_type": "document",
   "loc": {
     "start": {
       "line": 1,

--- a/test/testcases/codeblock/expected.json
+++ b/test/testcases/codeblock/expected.json
@@ -1,0 +1,661 @@
+{
+  "autofootnote_start": 1,
+  "symbol_footnote_start": 0,
+  "children": [
+    {
+      "source": "<stdin>",
+      "children": [
+        {
+          "type": "Str",
+          "raw": "code-block",
+          "value": "code-block",
+          "original_type": "text",
+          "range": [
+            0,
+            10
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 10
+            }
+          }
+        }
+      ],
+      "type": "Header",
+      "raw": "code-block",
+      "original_type": "title",
+      "range": [
+        0,
+        10
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 10
+        }
+      }
+    },
+    {
+      "source": "<stdin>",
+      "children": [
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": "{",
+              "value": "{",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": "{",
+          "original_type": "inline",
+          "range": [
+            0,
+            0
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 0
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": "\n    ",
+              "value": "\n    ",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": "\n    ",
+          "original_type": "inline",
+          "range": [
+            0,
+            0
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 0
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": "\"type\"",
+              "value": "\"type\"",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": "\"type\"",
+          "original_type": "inline",
+          "range": [
+            0,
+            0
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 0
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": ":",
+              "value": ":",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": ":",
+          "original_type": "inline",
+          "range": [
+            96,
+            97
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 14
+            },
+            "end": {
+              "line": 8,
+              "column": 15
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": " ",
+              "value": " ",
+              "original_type": "text",
+              "range": [
+                106,
+                107
+              ],
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 0
+                },
+                "end": {
+                  "line": 9,
+                  "column": 1
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": " ",
+          "original_type": "inline",
+          "range": [
+            82,
+            83
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 0
+            },
+            "end": {
+              "line": 8,
+              "column": 1
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": "\"fruit\"",
+              "value": "\"fruit\"",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": "\"fruit\"",
+          "original_type": "inline",
+          "range": [
+            0,
+            0
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 0
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": ",",
+              "value": ",",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": ",",
+          "original_type": "inline",
+          "range": [
+            0,
+            0
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 0
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": "\n    ",
+              "value": "\n    ",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": "\n    ",
+          "original_type": "inline",
+          "range": [
+            0,
+            0
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 0
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": "\"name\"",
+              "value": "\"name\"",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": "\"name\"",
+          "original_type": "inline",
+          "range": [
+            90,
+            96
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 8
+            },
+            "end": {
+              "line": 8,
+              "column": 14
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": ":",
+              "value": ":",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": ":",
+          "original_type": "inline",
+          "range": [
+            96,
+            97
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 14
+            },
+            "end": {
+              "line": 8,
+              "column": 15
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": " ",
+              "value": " ",
+              "original_type": "text",
+              "range": [
+                106,
+                107
+              ],
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 0
+                },
+                "end": {
+                  "line": 9,
+                  "column": 1
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": " ",
+          "original_type": "inline",
+          "range": [
+            82,
+            83
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 0
+            },
+            "end": {
+              "line": 8,
+              "column": 1
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": "\"apple\"",
+              "value": "\"apple\"",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": "\"apple\"",
+          "original_type": "inline",
+          "range": [
+            98,
+            105
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 16
+            },
+            "end": {
+              "line": 8,
+              "column": 23
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": "\n",
+              "value": "\n",
+              "original_type": "text",
+              "range": [
+                0,
+                0
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 0
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": "\n",
+          "original_type": "inline",
+          "range": [
+            0,
+            0
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 0
+            }
+          }
+        },
+        {
+          "children": [
+            {
+              "type": "Str",
+              "raw": "}",
+              "value": "}",
+              "original_type": "text",
+              "range": [
+                110,
+                111
+              ],
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 4
+                },
+                "end": {
+                  "line": 9,
+                  "column": 5
+                }
+              }
+            }
+          ],
+          "type": "Code",
+          "raw": "}",
+          "original_type": "inline",
+          "range": [
+            110,
+            111
+          ],
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 4
+            },
+            "end": {
+              "line": 9,
+              "column": 5
+            }
+          }
+        }
+      ],
+      "type": "CodeBlock",
+      "raw": "{\n    \"type\": \"fruit\",\n    \"name\": \"apple\"\n}",
+      "original_type": "literal_block",
+      "range": [
+        55,
+        99
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 4
+        },
+        "end": {
+          "line": 8,
+          "column": 17
+        }
+      }
+    }
+  ],
+  "type": "Document",
+  "raw": "",
+  "original_type": "document",
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 0
+    }
+  },
+  "range": [
+    0,
+    112
+  ]
+}

--- a/test/testcases/codeblock/input.rst
+++ b/test/testcases/codeblock/input.rst
@@ -1,0 +1,9 @@
+code-block
+==========
+
+.. code-block:: javascript
+
+    {
+        "type": "fruit",
+        "name": "apple"
+    }

--- a/test/testcases/comment/expected.json
+++ b/test/testcases/comment/expected.json
@@ -9,6 +9,7 @@
           "type": "Str",
           "raw": "コメントのテスト",
           "value": "コメントのテスト",
+          "original_type": "text",
           "range": [
             0,
             8
@@ -27,6 +28,7 @@
       ],
       "type": "Paragraph",
       "raw": "コメントのテスト",
+      "original_type": "paragraph",
       "range": [
         0,
         8
@@ -47,6 +49,7 @@
       "type": "Comment",
       "raw": "1行コメント",
       "value": "1行コメント",
+      "original_type": "comment",
       "range": [
         13,
         19
@@ -69,6 +72,7 @@
           "type": "Str",
           "raw": "本文\nテキスト",
           "value": "本文\nテキスト",
+          "original_type": "text",
           "range": [
             21,
             28
@@ -87,6 +91,7 @@
       ],
       "type": "Paragraph",
       "raw": "本文\nテキスト",
+      "original_type": "paragraph",
       "range": [
         21,
         28
@@ -107,6 +112,7 @@
       "type": "Comment",
       "raw": "複数行\nコメント",
       "value": "複数行\nコメント",
+      "original_type": "comment",
       "range": [
         37,
         45
@@ -129,6 +135,7 @@
           "type": "Str",
           "raw": "終わり",
           "value": "終わり",
+          "original_type": "text",
           "range": [
             51,
             54
@@ -147,6 +154,7 @@
       ],
       "type": "Paragraph",
       "raw": "終わり",
+      "original_type": "paragraph",
       "range": [
         51,
         54
@@ -165,6 +173,7 @@
   ],
   "type": "Document",
   "raw": "",
+  "original_type": "document",
   "loc": {
     "start": {
       "line": 1,


### PR DESCRIPTION
rst のノードと textlint のノードは 1 to 1 には対応しない。rst のほうがバリエーションが多く、また仕様上拡張可能である。
code-block などのブロックの開始位置を探り当てるためには rst のノード情報が必要なので、これを node.original_node という名前で保持することにした。位置補正をするかどうかのチェックでは、従来の node.type の代わりにこの node.original_type を用いる。

未解決の問題: ユーザーが sphinx plugin 等でディレクティブを追加している場合に、これをうまく処理するためにはブロックの定義を config で外から与えることができるようにすべき。例: mermaid

マージにおける注意: #4 の派生として実装しているので、マージ先は #4