### PR TITLE
textlint 13.x 対応の修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## shiguredo
 
+## develop
+
+- [CHANGE] textlint 13.x 環境下で動作するよう修正
+
 ## 2023.3.0
 
 - [ADD] デバッグ出力を設定で切替可能にする

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,8 @@
 
 ## develop
 
-- [CHANGE] textlint 13.x 環境下で動作するよう修正
+- [FIX] textlint 13.x 環境下で NodeType = Code のとき node.value が要求されるが、プラグイン側が対応できていない。これを textlint の要求に従うように修正する
+    - @max747
 
 ## 2023.3.0
 

--- a/lib/ReSTProcessor.js
+++ b/lib/ReSTProcessor.js
@@ -464,9 +464,9 @@ var require_structured_source = __commonJS({
   }
 });
 
-// node_modules/@textlint/ast-node-types/lib/src/index.js
-var require_src = __commonJS({
-  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+// node_modules/@textlint/ast-node-types/lib/src/ASTNodeTypes.js
+var require_ASTNodeTypes = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/ASTNodeTypes.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ASTNodeTypes = void 0;
@@ -512,7 +512,26 @@ var require_src = __commonJS({
       ASTNodeTypes4["CodeExit"] = "Code:exit";
       ASTNodeTypes4["Delete"] = "Delete";
       ASTNodeTypes4["DeleteExit"] = "Delete:exit";
+      ASTNodeTypes4["Table"] = "Table";
+      ASTNodeTypes4["TableExit"] = "Table:exit";
+      ASTNodeTypes4["TableRow"] = "TableRow";
+      ASTNodeTypes4["TableRowExit"] = "TableRow:exit";
+      ASTNodeTypes4["TableCell"] = "TableCell";
+      ASTNodeTypes4["TableCellExit"] = "TableCell:exit";
     })(ASTNodeTypes3 = exports.ASTNodeTypes || (exports.ASTNodeTypes = {}));
+  }
+});
+
+// node_modules/@textlint/ast-node-types/lib/src/index.js
+var require_src = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ASTNodeTypes = void 0;
+    var ASTNodeTypes_1 = require_ASTNodeTypes();
+    Object.defineProperty(exports, "ASTNodeTypes", { enumerable: true, get: function() {
+      return ASTNodeTypes_1.ASTNodeTypes;
+    } });
   }
 });
 
@@ -617,15 +636,19 @@ function parse(text, options) {
         node.type = syntaxMap[node.original_type];
       }
       if (!node.type) {
-        node.type = "Unknown";
+        node.type = import_ast_node_types2.ASTNodeTypes.Str;
       }
       node.raw = node.raw || node.value || "";
       if (node.value === void 0) {
-        if (node.type === import_ast_node_types2.ASTNodeTypes.Comment) {
-          node.value = node.raw;
-          delete node.children;
-        } else {
-          delete node.value;
+        switch (node.type) {
+          case import_ast_node_types2.ASTNodeTypes.Comment:
+          case import_ast_node_types2.ASTNodeTypes.Str:
+          case import_ast_node_types2.ASTNodeTypes.Code:
+            node.value = node.raw;
+            delete node.children;
+            break;
+          default:
+            delete node.value;
         }
       }
       if (node.line) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -464,9 +464,9 @@ var require_structured_source = __commonJS({
   }
 });
 
-// node_modules/@textlint/ast-node-types/lib/src/index.js
-var require_src = __commonJS({
-  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+// node_modules/@textlint/ast-node-types/lib/src/ASTNodeTypes.js
+var require_ASTNodeTypes = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/ASTNodeTypes.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ASTNodeTypes = void 0;
@@ -512,7 +512,26 @@ var require_src = __commonJS({
       ASTNodeTypes4["CodeExit"] = "Code:exit";
       ASTNodeTypes4["Delete"] = "Delete";
       ASTNodeTypes4["DeleteExit"] = "Delete:exit";
+      ASTNodeTypes4["Table"] = "Table";
+      ASTNodeTypes4["TableExit"] = "Table:exit";
+      ASTNodeTypes4["TableRow"] = "TableRow";
+      ASTNodeTypes4["TableRowExit"] = "TableRow:exit";
+      ASTNodeTypes4["TableCell"] = "TableCell";
+      ASTNodeTypes4["TableCellExit"] = "TableCell:exit";
     })(ASTNodeTypes3 = exports.ASTNodeTypes || (exports.ASTNodeTypes = {}));
+  }
+});
+
+// node_modules/@textlint/ast-node-types/lib/src/index.js
+var require_src = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ASTNodeTypes = void 0;
+    var ASTNodeTypes_1 = require_ASTNodeTypes();
+    Object.defineProperty(exports, "ASTNodeTypes", { enumerable: true, get: function() {
+      return ASTNodeTypes_1.ASTNodeTypes;
+    } });
   }
 });
 
@@ -617,15 +636,19 @@ function parse(text, options) {
         node.type = syntaxMap[node.original_type];
       }
       if (!node.type) {
-        node.type = "Unknown";
+        node.type = import_ast_node_types2.ASTNodeTypes.Str;
       }
       node.raw = node.raw || node.value || "";
       if (node.value === void 0) {
-        if (node.type === import_ast_node_types2.ASTNodeTypes.Comment) {
-          node.value = node.raw;
-          delete node.children;
-        } else {
-          delete node.value;
+        switch (node.type) {
+          case import_ast_node_types2.ASTNodeTypes.Comment:
+          case import_ast_node_types2.ASTNodeTypes.Str:
+          case import_ast_node_types2.ASTNodeTypes.Code:
+            node.value = node.raw;
+            delete node.children;
+            break;
+          default:
+            delete node.value;
         }
       }
       if (node.line) {

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -30,9 +30,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 ));
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
-// node_modules/@textlint/ast-node-types/lib/src/index.js
-var require_src = __commonJS({
-  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+// node_modules/@textlint/ast-node-types/lib/src/ASTNodeTypes.js
+var require_ASTNodeTypes = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/ASTNodeTypes.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ASTNodeTypes = void 0;
@@ -78,7 +78,26 @@ var require_src = __commonJS({
       ASTNodeTypes3["CodeExit"] = "Code:exit";
       ASTNodeTypes3["Delete"] = "Delete";
       ASTNodeTypes3["DeleteExit"] = "Delete:exit";
+      ASTNodeTypes3["Table"] = "Table";
+      ASTNodeTypes3["TableExit"] = "Table:exit";
+      ASTNodeTypes3["TableRow"] = "TableRow";
+      ASTNodeTypes3["TableRowExit"] = "TableRow:exit";
+      ASTNodeTypes3["TableCell"] = "TableCell";
+      ASTNodeTypes3["TableCellExit"] = "TableCell:exit";
     })(ASTNodeTypes2 = exports.ASTNodeTypes || (exports.ASTNodeTypes = {}));
+  }
+});
+
+// node_modules/@textlint/ast-node-types/lib/src/index.js
+var require_src = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ASTNodeTypes = void 0;
+    var ASTNodeTypes_1 = require_ASTNodeTypes();
+    Object.defineProperty(exports, "ASTNodeTypes", { enumerable: true, get: function() {
+      return ASTNodeTypes_1.ASTNodeTypes;
+    } });
   }
 });
 

--- a/lib/rst-to-ast.js
+++ b/lib/rst-to-ast.js
@@ -464,9 +464,9 @@ var require_structured_source = __commonJS({
   }
 });
 
-// node_modules/@textlint/ast-node-types/lib/src/index.js
-var require_src = __commonJS({
-  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+// node_modules/@textlint/ast-node-types/lib/src/ASTNodeTypes.js
+var require_ASTNodeTypes = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/ASTNodeTypes.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ASTNodeTypes = void 0;
@@ -512,7 +512,26 @@ var require_src = __commonJS({
       ASTNodeTypes4["CodeExit"] = "Code:exit";
       ASTNodeTypes4["Delete"] = "Delete";
       ASTNodeTypes4["DeleteExit"] = "Delete:exit";
+      ASTNodeTypes4["Table"] = "Table";
+      ASTNodeTypes4["TableExit"] = "Table:exit";
+      ASTNodeTypes4["TableRow"] = "TableRow";
+      ASTNodeTypes4["TableRowExit"] = "TableRow:exit";
+      ASTNodeTypes4["TableCell"] = "TableCell";
+      ASTNodeTypes4["TableCellExit"] = "TableCell:exit";
     })(ASTNodeTypes3 = exports.ASTNodeTypes || (exports.ASTNodeTypes = {}));
+  }
+});
+
+// node_modules/@textlint/ast-node-types/lib/src/index.js
+var require_src = __commonJS({
+  "node_modules/@textlint/ast-node-types/lib/src/index.js"(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ASTNodeTypes = void 0;
+    var ASTNodeTypes_1 = require_ASTNodeTypes();
+    Object.defineProperty(exports, "ASTNodeTypes", { enumerable: true, get: function() {
+      return ASTNodeTypes_1.ASTNodeTypes;
+    } });
   }
 });
 
@@ -616,15 +635,19 @@ function parse(text, options) {
         node.type = syntaxMap[node.original_type];
       }
       if (!node.type) {
-        node.type = "Unknown";
+        node.type = import_ast_node_types2.ASTNodeTypes.Str;
       }
       node.raw = node.raw || node.value || "";
       if (node.value === void 0) {
-        if (node.type === import_ast_node_types2.ASTNodeTypes.Comment) {
-          node.value = node.raw;
-          delete node.children;
-        } else {
-          delete node.value;
+        switch (node.type) {
+          case import_ast_node_types2.ASTNodeTypes.Comment:
+          case import_ast_node_types2.ASTNodeTypes.Str:
+          case import_ast_node_types2.ASTNodeTypes.Code:
+            node.value = node.raw;
+            delete node.children;
+            break;
+          default:
+            delete node.value;
         }
       }
       if (node.line) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "traverse": "0.6.7"
       },
       "devDependencies": {
-        "@textlint/ast-node-types": "12.3.0",
-        "@textlint/types": "12.5.0",
+        "@textlint/ast-node-types": "13.3.3",
+        "@textlint/types": "13.3.3",
         "@types/mocha": "^10.0.1",
         "@types/node": "18.11.18",
         "@types/traverse": "0.6.32",
@@ -26,12 +26,21 @@
         "eslint-config-prettier": "8.6.0",
         "mocha": "^10.2.0",
         "prettier": "2.8.1",
-        "textlint": "12.5.1",
+        "textlint": "13.3.3",
         "ts-node": "^10.9.1",
-        "typescript": "4.9.4"
+        "typescript": "5.1.6"
       },
       "engines": {
         "node": ">=18.12"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -437,9 +446,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -530,98 +539,59 @@
       }
     },
     "node_modules/@textlint/ast-node-types": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.3.0.tgz",
-      "integrity": "sha512-ke5hlKy/xZ/vQt6j+h4k9GradJPDsV3FKsUqWpCpF/X8qWCU2zM4e1SMUAFjoUcLuF9in+eXIQ71Qm/AdjjkZQ==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-13.3.3.tgz",
+      "integrity": "sha512-KCpJppfX3Km69twa6SmVEJ8mkyAZSrxw3XaaLQSlpc7PWnLUJSCHGPVECI1nSUDhiTd1r6zlRvWuyIAZJiov+A==",
       "dev": true
     },
     "node_modules/@textlint/ast-tester": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-12.6.1.tgz",
-      "integrity": "sha512-Gxiq6xmDR3PnX0RqRGth/Lu5fyFWoXNPfGxXTLORPFpfs8JKPh/eXGhlwc1f0v4VQzPay2KwVl6SGXvJD5qLXw==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-13.3.3.tgz",
+      "integrity": "sha512-vIIEJ0vDJb3Pr4kseOH9yzUCxx1EbX6PQDg/DgQj9sMAnwVG2sZvy2Uiga4+hj8SphdzaKia9Z+156UZzs+mzA==",
       "dev": true,
       "dependencies": {
-        "@textlint/ast-node-types": "^12.6.1",
+        "@textlint/ast-node-types": "^13.3.3",
         "debug": "^4.3.4"
       }
     },
-    "node_modules/@textlint/ast-tester/node_modules/@textlint/ast-node-types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
-      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
-      "dev": true
-    },
     "node_modules/@textlint/ast-traverse": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-12.6.1.tgz",
-      "integrity": "sha512-Y/j7ip7yDuTjuIV4kTRPVnkJKfpI71U+eqXFnrM9sE2xBA9IsqzqiLQeDY+S5hhfQzmcEnZFtAP0hqrYaT6gNA==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-13.3.3.tgz",
+      "integrity": "sha512-tZ25emmWf3mJ4+vM8CO6D7F8l00WXD6MJgnnlY9BHI/HbOlngBfmKhTVizQEwrWfYF80sQO5R9a+N4UEk67Wcg==",
       "dev": true,
       "dependencies": {
-        "@textlint/ast-node-types": "^12.6.1"
+        "@textlint/ast-node-types": "^13.3.3"
       }
     },
-    "node_modules/@textlint/ast-traverse/node_modules/@textlint/ast-node-types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
-      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
-      "dev": true
-    },
     "node_modules/@textlint/config-loader": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/config-loader/-/config-loader-12.6.1.tgz",
-      "integrity": "sha512-mvChF2pFusxyQC4gFzIgNcZ4izUt7ci+JdXZtGV+DOzykVUuGhgGo3TFTi/ccgYyqZdq9MxJG6I+dvYB1A2Fog==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/config-loader/-/config-loader-13.3.3.tgz",
+      "integrity": "sha512-DQA/7dYu3VDHP9Idd0Sn7HzwiFuNdKUXfA79pUGmJzNQUYaW0qADzyQCwfh7LlvhCcBmnLgX+8wb13o6OaHX5g==",
       "dev": true,
       "dependencies": {
-        "@textlint/kernel": "^12.6.1",
-        "@textlint/module-interop": "^12.6.1",
-        "@textlint/types": "^12.6.1",
-        "@textlint/utils": "^12.6.1",
+        "@textlint/kernel": "^13.3.3",
+        "@textlint/module-interop": "^13.3.3",
+        "@textlint/types": "^13.3.3",
+        "@textlint/utils": "^13.3.3",
         "debug": "^4.3.4",
-        "rc-config-loader": "^4.1.2",
+        "rc-config-loader": "^4.1.3",
         "try-resolve": "^1.0.1"
       }
     },
-    "node_modules/@textlint/config-loader/node_modules/@textlint/ast-node-types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
-      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
-      "dev": true
-    },
-    "node_modules/@textlint/config-loader/node_modules/@textlint/types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-12.6.1.tgz",
-      "integrity": "sha512-t1SZYahu2olnF8MUhlP6qDIEDyl7WmyIaBYxQdE2qU6xUkZWXS2zIxoAT/pVgvFCzDw3KO5HhIYGVeWRp90dTg==",
-      "dev": true,
-      "dependencies": {
-        "@textlint/ast-node-types": "^12.6.1"
-      }
-    },
-    "node_modules/@textlint/config-loader/node_modules/rc-config-loader": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.2.tgz",
-      "integrity": "sha512-qKTnVWFl9OQYKATPzdfaZIbTxcHziQl92zYSxYC6umhOqyAsoj8H8Gq/+aFjAso68sBdjTz3A7omqeAkkF1MWg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "js-yaml": "^4.1.0",
-        "json5": "^2.2.2",
-        "require-from-string": "^2.0.2"
-      }
-    },
     "node_modules/@textlint/feature-flag": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-12.6.1.tgz",
-      "integrity": "sha512-cY/AraTLdzbwDyAhdpaXB7n1Lw6zA+k+7UaT8mmxMmjs0uYGzdMQa499I0rQatctJ6izrdZXYW0NdUQfG2ugiA==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-13.3.3.tgz",
+      "integrity": "sha512-ltdwKQTvs9f/TgQ3asBx2EXmsSSsvxa7ySnTXSTZBkbVxqmrGY4zehDRiDCmuFZGVGCvCddY1QzCXy16ybk9Fg==",
       "dev": true
     },
     "node_modules/@textlint/fixer-formatter": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-12.6.1.tgz",
-      "integrity": "sha512-BMhvoKQbME9LXvl6CfIM/hZckb+IMiAA6ioDvdM3o63N+xDypS42uzJNpRgzXKGYL1Dv/7R1hsmDzz3fgvGhBw==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-13.3.3.tgz",
+      "integrity": "sha512-iCMFS8GrmUetXMIT4/jFxoL5v1QN5ODj1190Lb6D+EdTxsrAWssHOb6m7MOEhfOGYEArAkb3PjSxu7DPLrb50g==",
       "dev": true,
       "dependencies": {
-        "@textlint/module-interop": "^12.6.1",
-        "@textlint/types": "^12.6.1",
+        "@textlint/module-interop": "^13.3.3",
+        "@textlint/types": "^13.3.3",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "diff": "^4.0.2",
@@ -630,21 +600,6 @@
         "strip-ansi": "^6.0.1",
         "text-table": "^0.2.0",
         "try-resolve": "^1.0.1"
-      }
-    },
-    "node_modules/@textlint/fixer-formatter/node_modules/@textlint/ast-node-types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
-      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
-      "dev": true
-    },
-    "node_modules/@textlint/fixer-formatter/node_modules/@textlint/types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-12.6.1.tgz",
-      "integrity": "sha512-t1SZYahu2olnF8MUhlP6qDIEDyl7WmyIaBYxQdE2qU6xUkZWXS2zIxoAT/pVgvFCzDw3KO5HhIYGVeWRp90dTg==",
-      "dev": true,
-      "dependencies": {
-        "@textlint/ast-node-types": "^12.6.1"
       }
     },
     "node_modules/@textlint/fixer-formatter/node_modules/diff": {
@@ -657,75 +612,44 @@
       }
     },
     "node_modules/@textlint/kernel": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-12.6.1.tgz",
-      "integrity": "sha512-GjNaI36pYx/boy1Xf7NPJFbS0uWHhY9y9DMMl/8ZJZoldN7XrCvJFivNdeYQxu+LTmfGGaUJoTjDpnllOs6XSQ==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-13.3.3.tgz",
+      "integrity": "sha512-HewzuuX2c2nlR+e8dREWrAYrOiyWb78eeObuW95miMjX/F6TjWmha4qrnrMCWbYbKDwC4en8dNGS4mm0vSdi4A==",
       "dev": true,
       "dependencies": {
-        "@textlint/ast-node-types": "^12.6.1",
-        "@textlint/ast-tester": "^12.6.1",
-        "@textlint/ast-traverse": "^12.6.1",
-        "@textlint/feature-flag": "^12.6.1",
-        "@textlint/source-code-fixer": "^12.6.1",
-        "@textlint/types": "^12.6.1",
-        "@textlint/utils": "^12.6.1",
+        "@textlint/ast-node-types": "^13.3.3",
+        "@textlint/ast-tester": "^13.3.3",
+        "@textlint/ast-traverse": "^13.3.3",
+        "@textlint/feature-flag": "^13.3.3",
+        "@textlint/source-code-fixer": "^13.3.3",
+        "@textlint/types": "^13.3.3",
+        "@textlint/utils": "^13.3.3",
         "debug": "^4.3.4",
-        "deep-equal": "^1.1.1",
+        "fast-equals": "^4.0.3",
         "structured-source": "^4.0.0"
       }
     },
-    "node_modules/@textlint/kernel/node_modules/@textlint/ast-node-types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
-      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
-      "dev": true
-    },
-    "node_modules/@textlint/kernel/node_modules/@textlint/types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-12.6.1.tgz",
-      "integrity": "sha512-t1SZYahu2olnF8MUhlP6qDIEDyl7WmyIaBYxQdE2qU6xUkZWXS2zIxoAT/pVgvFCzDw3KO5HhIYGVeWRp90dTg==",
-      "dev": true,
-      "dependencies": {
-        "@textlint/ast-node-types": "^12.6.1"
-      }
-    },
     "node_modules/@textlint/linter-formatter": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-12.6.1.tgz",
-      "integrity": "sha512-1fQy17vNZy5qem8I71MGEir7gVLSUWcIE4ruQbONiIko9as+AYibt6xX6GtTX+aJejuJJcb+KTeAxKJ+6FA8vg==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-13.3.3.tgz",
+      "integrity": "sha512-z8xsk1bo9r8v6Ph76WLTBrfj+0+eyEfRlbTGBs+ie6YAGItBqkLYmDrD26DDfVjIZcXWdCXVX1Et6MOWomb//g==",
       "dev": true,
       "dependencies": {
-        "@azu/format-text": "^1.0.1",
-        "@azu/style-format": "^1.0.0",
-        "@textlint/module-interop": "^12.6.1",
-        "@textlint/types": "^12.6.1",
+        "@azu/format-text": "^1.0.2",
+        "@azu/style-format": "^1.0.1",
+        "@textlint/module-interop": "^13.3.3",
+        "@textlint/types": "^13.3.3",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "is-file": "^1.0.0",
         "js-yaml": "^3.14.1",
         "lodash": "^4.17.21",
-        "optionator": "^0.9.1",
         "pluralize": "^2.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "table": "^6.8.1",
         "text-table": "^0.2.0",
         "try-resolve": "^1.0.1"
-      }
-    },
-    "node_modules/@textlint/linter-formatter/node_modules/@textlint/ast-node-types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
-      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
-      "dev": true
-    },
-    "node_modules/@textlint/linter-formatter/node_modules/@textlint/types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-12.6.1.tgz",
-      "integrity": "sha512-t1SZYahu2olnF8MUhlP6qDIEDyl7WmyIaBYxQdE2qU6xUkZWXS2zIxoAT/pVgvFCzDw3KO5HhIYGVeWRp90dTg==",
-      "dev": true,
-      "dependencies": {
-        "@textlint/ast-node-types": "^12.6.1"
       }
     },
     "node_modules/@textlint/linter-formatter/node_modules/argparse": {
@@ -751,12 +675,12 @@
       }
     },
     "node_modules/@textlint/markdown-to-ast": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-12.6.1.tgz",
-      "integrity": "sha512-T0HO+VrU9VbLRiEx/kH4+gwGMHNMIGkp0Pok+p0I33saOOLyhfGvwOKQgvt2qkxzQEV2L5MtGB8EnW4r5d3CqQ==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-13.3.3.tgz",
+      "integrity": "sha512-jeqWyChTtJHWxEnH46V6qjr+OCTh6evm45aDqMzdg+b8ocXY+NhudiCMeHcVGoz042UEwc6w4reLn8+Is+SZ+A==",
       "dev": true,
       "dependencies": {
-        "@textlint/ast-node-types": "^12.6.1",
+        "@textlint/ast-node-types": "^13.3.3",
         "debug": "^4.3.4",
         "mdast-util-gfm-autolink-literal": "^0.1.3",
         "remark-footnotes": "^3.0.0",
@@ -767,89 +691,62 @@
         "unified": "^9.2.2"
       }
     },
-    "node_modules/@textlint/markdown-to-ast/node_modules/@textlint/ast-node-types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
-      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
-      "dev": true
-    },
     "node_modules/@textlint/module-interop": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-12.6.1.tgz",
-      "integrity": "sha512-COyRctLVh2ktAObmht3aNtqUvP0quoellKu1c2RrXny1po+Mf7PkvEKIxphtArE4JXMAmu01cDxfH6X88+eYIg==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-13.3.3.tgz",
+      "integrity": "sha512-CwfVpRGAxbkhGY9vLLU06Q/dy/RMNnyzbmt6IS2WIyxqxvGaF7QZtFYpKEEm63aemVyUvzQ7WM3yVOoUg6P92w==",
       "dev": true
     },
     "node_modules/@textlint/source-code-fixer": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-12.6.1.tgz",
-      "integrity": "sha512-J9UZ3uitT+T50ug5X6AoIOwn6kTl54ZmPYBPB9bmH4lwBamN7e4gT65lSweHY1D21elOkq+3bO/OAJMfQfAVHg==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-13.3.3.tgz",
+      "integrity": "sha512-h4jxWSetmcVuGwl71ai72784aneBQ0MkE5Mc3avl8PKIOIOyz0A1D7i9VQENWWIiqU8zyzmHwKGNSGyqWaqE2Q==",
       "dev": true,
       "dependencies": {
-        "@textlint/types": "^12.6.1",
+        "@textlint/types": "^13.3.3",
         "debug": "^4.3.4"
       }
     },
-    "node_modules/@textlint/source-code-fixer/node_modules/@textlint/ast-node-types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
-      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
-      "dev": true
-    },
-    "node_modules/@textlint/source-code-fixer/node_modules/@textlint/types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-12.6.1.tgz",
-      "integrity": "sha512-t1SZYahu2olnF8MUhlP6qDIEDyl7WmyIaBYxQdE2qU6xUkZWXS2zIxoAT/pVgvFCzDw3KO5HhIYGVeWRp90dTg==",
-      "dev": true,
-      "dependencies": {
-        "@textlint/ast-node-types": "^12.6.1"
-      }
-    },
     "node_modules/@textlint/text-to-ast": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-12.6.1.tgz",
-      "integrity": "sha512-22tgSBaNerpwb66eCivjXmdZ3CDX2Il38vpuAGchiI+cl+sENU9dpuntxwEJdZQePX5qrkmw8XGj5kgyMF015A==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-13.3.3.tgz",
+      "integrity": "sha512-iQdiHAiUfB9XruuYWCb4fY/gD/Q5/MkH1xwUTpS8UJowNgwpTldagUJX1JbZQ2UHux+yRe9JFA+JKm3rrxgQFw==",
       "dev": true,
       "dependencies": {
-        "@textlint/ast-node-types": "^12.6.1"
+        "@textlint/ast-node-types": "^13.3.3"
       }
-    },
-    "node_modules/@textlint/text-to-ast/node_modules/@textlint/ast-node-types": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
-      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
-      "dev": true
     },
     "node_modules/@textlint/textlint-plugin-markdown": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-12.6.1.tgz",
-      "integrity": "sha512-fRKsFCL2fGeu0Bt+08FuEc2WHiI8IMDRvy6KT1pmNWO5irS4yL2/OXNknLH3erXvwcJw/hQnd5WEl4hQzS0Erw==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-13.3.3.tgz",
+      "integrity": "sha512-EhBZ/Q6ZXMVRPDeQbFdFbtc0wE7SC0DWy9lkjKXfcbLKW0ZPTvtjH3JqJtCPBZAYcexB8wKOiHImfwVfQJhJhg==",
       "dev": true,
       "dependencies": {
-        "@textlint/markdown-to-ast": "^12.6.1"
+        "@textlint/markdown-to-ast": "^13.3.3"
       }
     },
     "node_modules/@textlint/textlint-plugin-text": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-12.6.1.tgz",
-      "integrity": "sha512-ZUfG0Xb8qGymIPNp2eFTq9bHvkJo3N3Ia1Aff5W9fsgZib1/Eb55U16Sp60TjhBFns0/p7L7usBC3nd3+tB5mQ==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-13.3.3.tgz",
+      "integrity": "sha512-MN/JMGLanqj8CJGuit8DDiyrO0yf1vxFMLWTDeMIXwSoe8VToHCt2j20zg8XNHGNrUbKj+wuhzhrkrKEI7uWxg==",
       "dev": true,
       "dependencies": {
-        "@textlint/text-to-ast": "^12.6.1"
+        "@textlint/text-to-ast": "^13.3.3"
       }
     },
     "node_modules/@textlint/types": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-12.5.0.tgz",
-      "integrity": "sha512-Po5qOubilL/g3dx+ZUgaQzNXbROADBF4Z5xy7qqgV6pBQIEE/06INZDmmLE1Eesm2zoDpygoG/1f/0/Cy5Yupw==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-13.3.3.tgz",
+      "integrity": "sha512-i2B7uRh+Iv8ZBKPJ3n4I6uSrTUQq5LdEkhFYNUwnDYxmhudz1o79xm906kri2eM8lxThX/UYYgVuJWpEwS0b+g==",
       "dev": true,
       "dependencies": {
-        "@textlint/ast-node-types": "^12.3.0"
+        "@textlint/ast-node-types": "^13.3.3"
       }
     },
     "node_modules/@textlint/utils": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-12.6.1.tgz",
-      "integrity": "sha512-HJkqYXT2FAAHDM5XLFpQLF/CEdm8c2ltMeKmPBSSty1VfPXQMi8tGPT1b58b8KWh6dVmi7w0YYB7NrquuzXOKA==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-13.3.3.tgz",
+      "integrity": "sha512-roN+K3a36RxGc0tV+8HXVXpoPomEr3LCjNI8+hFmVjOu3RsUdLTyraNBqqaghaE0KgwCPODF0seuG1hteNI8LQ==",
       "dev": true
     },
     "node_modules/@tsconfig/node10": {
@@ -871,24 +768,24 @@
       "dev": true
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
     "node_modules/@types/mdast": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
-      "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
+      "integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
       "dev": true,
       "dependencies": {
-        "@types/unist": "*"
+        "@types/unist": "^2"
       }
     },
     "node_modules/@types/mocha": {
@@ -904,9 +801,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "node_modules/@types/traverse": {
@@ -916,9 +813,9 @@
       "dev": true
     },
     "node_modules/@types/unist": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
+      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1109,9 +1006,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1287,19 +1184,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1518,44 +1402,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
-      "dependencies": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
-      "dev": true,
-      "dependencies": {
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -1772,9 +1623,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1784,9 +1635,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -1794,6 +1645,9 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/estraverse": {
@@ -1806,14 +1660,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
-      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.8.0",
+        "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.0"
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1907,10 +1761,16 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "dev": true
+    },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2053,9 +1913,9 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -2072,15 +1932,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2088,20 +1939,6 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-stdin": {
@@ -2146,9 +1983,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2211,45 +2048,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
-      "dependencies": {
-        "has-symbols": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/he": {
@@ -2341,22 +2139,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2382,27 +2164,12 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2491,22 +2258,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -2532,9 +2283,9 @@
       "dev": true
     },
     "node_modules/js-sdsl": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
-      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
+      "integrity": "sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -3177,9 +2928,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -3194,31 +2945,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3229,17 +2955,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -3485,37 +3211,15 @@
       }
     },
     "node_modules/rc-config-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-3.0.0.tgz",
-      "integrity": "sha512-bwfUSB37TWkHfP+PPjb/x8BUjChFmmBK44JMfVnU7paisWqZl/o5k7ttCH+EQLnrbn2Aq8Fo1LAsyUiz+WF4CQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
+      "integrity": "sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.1.1",
-        "js-yaml": "^3.12.0",
-        "json5": "^2.1.1",
+        "debug": "^4.3.4",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.2",
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/rc-config-loader/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/rc-config-loader/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/read-pkg": {
@@ -3701,23 +3405,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -3813,12 +3500,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -3907,9 +3594,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4142,25 +3829,24 @@
       "dev": true
     },
     "node_modules/textlint": {
-      "version": "12.5.1",
-      "resolved": "https://registry.npmjs.org/textlint/-/textlint-12.5.1.tgz",
-      "integrity": "sha512-LoFU1yBIm/gxM++jDdvdfS2diW14NBHsimRyChi8Kb5h5pUHcG0rGfW2PflUzfYcHF0XykgW9WBdPd1WWnyS7Q==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/textlint/-/textlint-13.3.3.tgz",
+      "integrity": "sha512-1LhJTNBFVNYtl4C6IJXt1XwAJANvquyDuP4NrhcG+1DwT3S7kiUR9vLo5yo046X83VT7ownzS97Q/yC6A7bZXg==",
       "dev": true,
       "dependencies": {
-        "@textlint/ast-node-types": "^12.3.0",
-        "@textlint/ast-traverse": "^12.5.0",
-        "@textlint/config-loader": "^12.5.0",
-        "@textlint/feature-flag": "^12.5.0",
-        "@textlint/fixer-formatter": "^12.5.1",
-        "@textlint/kernel": "^12.5.0",
-        "@textlint/linter-formatter": "^12.5.0",
-        "@textlint/module-interop": "^12.5.0",
-        "@textlint/textlint-plugin-markdown": "^12.5.0",
-        "@textlint/textlint-plugin-text": "^12.5.0",
-        "@textlint/types": "^12.5.0",
-        "@textlint/utils": "^12.5.0",
+        "@textlint/ast-node-types": "^13.3.3",
+        "@textlint/ast-traverse": "^13.3.3",
+        "@textlint/config-loader": "^13.3.3",
+        "@textlint/feature-flag": "^13.3.3",
+        "@textlint/fixer-formatter": "^13.3.3",
+        "@textlint/kernel": "^13.3.3",
+        "@textlint/linter-formatter": "^13.3.3",
+        "@textlint/module-interop": "^13.3.3",
+        "@textlint/textlint-plugin-markdown": "^13.3.3",
+        "@textlint/textlint-plugin-text": "^13.3.3",
+        "@textlint/types": "^13.3.3",
+        "@textlint/utils": "^13.3.3",
         "debug": "^4.3.4",
-        "deep-equal": "^1.1.1",
         "file-entry-cache": "^5.0.1",
         "get-stdin": "^5.0.1",
         "glob": "^7.2.3",
@@ -4169,26 +3855,19 @@
         "mkdirp": "^0.5.6",
         "optionator": "^0.9.1",
         "path-to-glob-pattern": "^1.0.2",
-        "rc-config-loader": "^3.0.0",
+        "rc-config-loader": "^4.1.3",
         "read-pkg": "^1.1.0",
         "read-pkg-up": "^3.0.0",
-        "structured-source": "^3.0.2",
+        "structured-source": "^4.0.0",
         "try-resolve": "^1.0.1",
         "unique-concat": "^0.2.2"
       },
       "bin": {
-        "textlint": "bin/textlint.js",
-        "textlint-esm": "bin/textlint-esm.js"
+        "textlint": "bin/textlint.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=16.0.0"
       }
-    },
-    "node_modules/textlint/node_modules/boundary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
-      "integrity": "sha512-AaLhxHwYVh55iOTJncV3DE5o7RakEUSSj64XXEWRTiIhlp7aDI8qR0vY/k8Uw0Z234VjZi/iG/WxfrvqYPUCww==",
-      "dev": true
     },
     "node_modules/textlint/node_modules/file-entry-cache": {
       "version": "5.0.1",
@@ -4252,15 +3931,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/textlint/node_modules/structured-source": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
-      "integrity": "sha512-Ap7JHfKgmH40SUjumqyKTHYHNZ8GvGQskP34ks0ElHCDEig+bYGpmXVksxPSrgcY9rkJqhVMzfeg5GIpZelfpQ==",
-      "dev": true,
-      "dependencies": {
-        "boundary": "^1.0.1"
       }
     },
     "node_modules/to-regex-range": {
@@ -4397,16 +4067,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unified": {
@@ -4584,15 +4254,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/workerpool": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "traverse": "0.6.7"
   },
   "devDependencies": {
-    "@textlint/ast-node-types": "12.3.0",
-    "@textlint/types": "12.5.0",
+    "@textlint/ast-node-types": "13.3.3",
+    "@textlint/types": "13.3.3",
     "@types/mocha": "^10.0.1",
     "@types/node": "18.11.18",
     "@types/traverse": "0.6.32",
@@ -45,9 +45,9 @@
     "eslint-config-prettier": "8.6.0",
     "mocha": "^10.2.0",
     "prettier": "2.8.1",
-    "textlint": "12.5.1",
+    "textlint": "13.3.3",
     "ts-node": "^10.9.1",
-    "typescript": "4.9.4"
+    "typescript": "5.1.6"
   },
   "engines": {
     "node": ">=18.12"

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -3,7 +3,7 @@
 import { ASTNodeTypes } from "@textlint/ast-node-types";
 
 interface SyntaxMap {
-    [index: string]: ASTNodeTypes
+    [index: string]: keyof typeof ASTNodeTypes
 }
 
 export const syntaxMap: SyntaxMap = {

--- a/src/rst-to-ast.ts
+++ b/src/rst-to-ast.ts
@@ -86,18 +86,23 @@ export function parse(text: string, options?: ParseOptions): TxtParentNode {
         node.type = syntaxMap[node.original_type]
       }
       if (!node.type) {
-        node.type = 'Unknown'
+        // textlint v13.0.5 以降で ASTNodeTypes 以外を受け付けなくなったので node.type = 'Unknown' のような代入はできない
+        node.type = ASTNodeTypes.Str
       }
       // raw
       node.raw = node.raw || node.value || ''
       // value
       if (node.value === undefined) {
-        // comment ノードは value を持つ必要がある。また children は不要
-        if (node.type === ASTNodeTypes.Comment) {
-          node.value = node.raw
-          delete node.children
-        } else {
-          delete node.value
+        // comment, str, code ノードは value を持つ必要がある。また children は不要
+        switch (node.type) {
+          case ASTNodeTypes.Comment:
+          case ASTNodeTypes.Str:
+          case ASTNodeTypes.Code:
+            node.value = node.raw
+            delete node.children
+            break
+          default:
+            delete node.value
         }
       }
       // loc

--- a/test/testcases/codeblock/expected.json
+++ b/test/testcases/codeblock/expected.json
@@ -48,30 +48,9 @@
       "source": "<stdin>",
       "children": [
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": "{",
-              "value": "{",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": "{",
+          "value": "{",
           "original_type": "inline",
           "range": [
             0,
@@ -89,30 +68,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": "\n    ",
-              "value": "\n    ",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": "\n    ",
+          "value": "\n    ",
           "original_type": "inline",
           "range": [
             0,
@@ -130,30 +88,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": "\"type\"",
-              "value": "\"type\"",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": "\"type\"",
+          "value": "\"type\"",
           "original_type": "inline",
           "range": [
             0,
@@ -171,30 +108,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": ":",
-              "value": ":",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": ":",
+          "value": ":",
           "original_type": "inline",
           "range": [
             96,
@@ -212,30 +128,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": " ",
-              "value": " ",
-              "original_type": "text",
-              "range": [
-                106,
-                107
-              ],
-              "loc": {
-                "start": {
-                  "line": 9,
-                  "column": 0
-                },
-                "end": {
-                  "line": 9,
-                  "column": 1
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": " ",
+          "value": " ",
           "original_type": "inline",
           "range": [
             82,
@@ -253,30 +148,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": "\"fruit\"",
-              "value": "\"fruit\"",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": "\"fruit\"",
+          "value": "\"fruit\"",
           "original_type": "inline",
           "range": [
             0,
@@ -294,30 +168,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": ",",
-              "value": ",",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": ",",
+          "value": ",",
           "original_type": "inline",
           "range": [
             0,
@@ -335,30 +188,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": "\n    ",
-              "value": "\n    ",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": "\n    ",
+          "value": "\n    ",
           "original_type": "inline",
           "range": [
             0,
@@ -376,30 +208,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": "\"name\"",
-              "value": "\"name\"",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": "\"name\"",
+          "value": "\"name\"",
           "original_type": "inline",
           "range": [
             90,
@@ -417,30 +228,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": ":",
-              "value": ":",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": ":",
+          "value": ":",
           "original_type": "inline",
           "range": [
             96,
@@ -458,30 +248,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": " ",
-              "value": " ",
-              "original_type": "text",
-              "range": [
-                106,
-                107
-              ],
-              "loc": {
-                "start": {
-                  "line": 9,
-                  "column": 0
-                },
-                "end": {
-                  "line": 9,
-                  "column": 1
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": " ",
+          "value": " ",
           "original_type": "inline",
           "range": [
             82,
@@ -499,30 +268,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": "\"apple\"",
-              "value": "\"apple\"",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": "\"apple\"",
+          "value": "\"apple\"",
           "original_type": "inline",
           "range": [
             98,
@@ -540,30 +288,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": "\n",
-              "value": "\n",
-              "original_type": "text",
-              "range": [
-                0,
-                0
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 0
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": "\n",
+          "value": "\n",
           "original_type": "inline",
           "range": [
             0,
@@ -581,30 +308,9 @@
           }
         },
         {
-          "children": [
-            {
-              "type": "Str",
-              "raw": "}",
-              "value": "}",
-              "original_type": "text",
-              "range": [
-                110,
-                111
-              ],
-              "loc": {
-                "start": {
-                  "line": 9,
-                  "column": 4
-                },
-                "end": {
-                  "line": 9,
-                  "column": 5
-                }
-              }
-            }
-          ],
           "type": "Code",
           "raw": "}",
+          "value": "}",
           "original_type": "inline",
           "range": [
             110,


### PR DESCRIPTION
textlint 13 系と併用した場合に問題が生じていた。 
textlint 13 系では `node.type = ASTNodeTypes.Code` の場合 `node.value`　が存在するという仮定があるが、このプラグインではそうなっていなかった。

- ASTNodeTypes.Code
- ASTNodeTypes.Str
- ASTNodeTypes.Comment (これは従来からそう)

の場合は明示的に `node.value` を与え、一方で `node.children` は存在しないものとして扱うようにした。